### PR TITLE
Fixed biters showing as factory units on defeat screen

### DIFF
--- a/js/modules/fightSystem.js
+++ b/js/modules/fightSystem.js
@@ -210,13 +210,10 @@ class Battle {
       case "win":
         this.result = "Victory 🎖";
 
-
         addRewardsToMilitaryHQParcel(window.parcels.parcelList, rewards);
 
         // Call displayBattleResult directly from afterBattle
-        displayBattleResult(this.result, rewards, ammunitionUsed, defeatedFactoryUnitCount, defeatedBiterUnitCount);
-
-
+        displayBattleResult(this.result, ammunitionUsed, defeatedFactoryUnitCount, defeatedBiterUnitCount, rewards);
 
         // Increment pollution factor, for example
         gameState.pollution.pollutionBiterFactor += 0.005;
@@ -942,7 +939,7 @@ function deductArmyCost(selectedParcel, armyCost, factoryUnits) {
   });
 }
 
-function displayBattleResult(result, reward = {alienArtefacts: 0}, ammunitionUsed = {}, defeatedFactoryUnits = [], defeatedBiterUnits = []) {
+function displayBattleResult(result, ammunitionUsed = {}, defeatedFactoryUnits = [], defeatedBiterUnits = [], reward = {alienArtefacts: 0}) {
   const fightContainer = document.getElementById("fight-container");
 
   // Create overlay


### PR DESCRIPTION
Hopefully fixed the bug where losing in battle shows biters lost instead of factory units lost

It looks like the 'rewards' variable was pushing everything else to the right one slot. So only the 'victory' state would have shown the right results

Solution: moved 'rewards' to the end of the list so it only appears when a reward is given

displayBattleResult(this.result, ammunitionUsed, defeatedFactoryUnitCount, defeatedBiterUnitCount, REWARDS);

I have read and agreed to the CLA

Before:
![image](https://user-images.githubusercontent.com/76602007/231602853-3c4abeae-3469-4c1e-a35a-a42c017f71c4.png)

After:
![image](https://user-images.githubusercontent.com/76602007/231602866-64c2cb33-b127-40c7-903e-a6450c2f4088.png)
