### PR TITLE
Easier Parcel Renaming

### DIFF
--- a/js/modules/parcelManipulation.js
+++ b/js/modules/parcelManipulation.js
@@ -19,9 +19,16 @@ document.addEventListener("DOMContentLoaded", () => {
   // Rename
   document.getElementById('renameDropdownItem').addEventListener('click', () => {
       document.getElementById('renameParcelOverlay').style.display = 'flex';
+      const input = document.getElementById('parcelNameInput')
+      input.focus();
+      input.addEventListener("keypress", (event) => {
+        if (event.key === "Enter") 
+          document.getElementById("renameParcelButton").click();
+      });
   });
 
   document.getElementById('renameParcelButton').addEventListener('click', () => {
+      document.getElementById('parcelNameInput').removeEventListener("keypress", event)
       parcelManipulation.renameParcel();
       document.getElementById('renameParcelOverlay').style.display = 'none';
   });

--- a/js/modules/parcelManipulation.js
+++ b/js/modules/parcelManipulation.js
@@ -20,6 +20,7 @@ document.addEventListener("DOMContentLoaded", () => {
   document.getElementById('renameDropdownItem').addEventListener('click', () => {
       document.getElementById('renameParcelOverlay').style.display = 'flex';
       const input = document.getElementById('parcelNameInput')
+      input.value = "";
       input.focus();
       input.addEventListener("keypress", (event) => {
         if (event.key === "Enter") 


### PR DESCRIPTION
Might have accidentally done 2 commits for this one, github is dumb sometimes

Just a little QOL fix, I'm trying to fix the bugs that a user will get multiple times in the same playthrough

1. Renaming a parcel now automatically selects the input field so the user doesn't have to manually click to start typing
2. Hitting 'enter' will also submit the name
3. Name field is cleared so user doesn't have to backspace a ton