### PR TITLE
Added gap between buttons and main tables put in flexbox

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -172,9 +172,10 @@ h1 {
 
 /* Parcels styles */
 #parcels {
-    display: block;
+    display: flex;
     flex-wrap: wrap;
-    justify-content: center;
+    flex-direction: row;
+    gap: 5px;
 }
 
 .parcel {
@@ -229,7 +230,9 @@ h1 {
 
 #building-tabs {
   display: flex;
+  flex-wrap: wrap;
   justify-content: start;
+  gap: 5px;
   margin-bottom: 10px;
 }
 
@@ -649,4 +652,11 @@ h1 {
 .buttonWrapper {
     float: right;
     margin-left: 1em;
+}
+
+.main-flexbox {
+    display: flex;
+    flex-wrap: wrap;
+    flex-direction: row;
+    gap: 40px;
 }

--- a/index.html
+++ b/index.html
@@ -221,86 +221,87 @@
 
 
         </div>
-
-        <div class="game-section">
-          <div class="parcel-manipulation">
-            <h2 id="parcelNameDisplay" class="parcel-name">Parcel 1</h2>
-            <button id="parcelManipulationMenuButton" class="menu-button">⚙</button>
-            <div id="parcelManipulationMenu" class="menu hidden">
-              <button id="renameDropdownItem" class="menu-item">Rename</button>
-              <button id="changeColorDropdownItem" class="menu-item">Change Color</button>
-              <button id="moveDropdownItem" class="menu-item">Move</button>
-              <button id="copyDropdownItem" class="menu-item">Copy</button>
-              <button id="pasteDropdownItem" class="menu-item">Paste</button>
-            </div>
-            <!-- Rename Popup -->
-            <div id="renameParcelOverlay" class="parcel-manipulation-overlay" style="display: none;">
+        <div class="main-flexbox">
+          <div class="game-section">
+            <div class="parcel-manipulation">
+              <h2 id="parcelNameDisplay" class="parcel-name">Parcel 1</h2>
+              <button id="parcelManipulationMenuButton" class="menu-button">⚙</button>
+              <div id="parcelManipulationMenu" class="menu hidden">
+                <button id="renameDropdownItem" class="menu-item">Rename</button>
+                <button id="changeColorDropdownItem" class="menu-item">Change Color</button>
+                <button id="moveDropdownItem" class="menu-item">Move</button>
+                <button id="copyDropdownItem" class="menu-item">Copy</button>
+                <button id="pasteDropdownItem" class="menu-item">Paste</button>
+              </div>
+              <!-- Rename Popup -->
+              <div id="renameParcelOverlay" class="parcel-manipulation-overlay" style="display: none;">
+                  <div class="parcel-manipulation-container">
+                      <label for="parcelNameInput">Rename parcel:</label>
+                      <input type="text" id="parcelNameInput" placeholder="New parcel name">
+                      <button id="renameParcelButton">Rename</button>
+                      <button id="closeRenameParcelOverlay">Cancel</button>
+                  </div>
+              </div>
+              <!-- Color Picker Popup -->
+              <div id="colorPickerOverlay" class="parcel-manipulation-overlay" style="display: none;">
+                  <div class="parcel-manipulation-container">
+                      <label for="colorPickerInput">Change parcel color:</label>
+                      <input type="color" id="colorPickerInput">
+                      <button id="applyColorButton">Change</button>
+                      <button id="reset-color-btn">Reset Color</button>
+                      <button id="closeColorPickerOverlay">Cancel</button>
+                  </div>
+              </div>
+              <!-- Move Popup -->
+              <div id="moveParcelOverlay" class="parcel-manipulation-overlay" style="display: none;">
+                  <div class="parcel-manipulation-container">
+                      <label for="parcelMoveInput">Move parcel:</label>
+                      <div class="input-controller">
+                          <div class="input-btn" id="decreaseMoveAmount">-</div>
+                          <input type="number" id="parcelMoveInput" class="input-display" value="1" min="1" placeholder="Enter move amount">
+                          <div class="input-btn" id="increaseMoveAmount">+</div>
+                      </div>
+                      <button id="moveParcelButton">Move</button>
+                      <button id="closeMoveParcelOverlay">Cancel</button>
+                  </div>
+              </div>
+              <!-- Paste Summary Popup -->
+              <div id="pasteSummaryOverlay" class="parcel-manipulation-overlay" style="display: none;">
                 <div class="parcel-manipulation-container">
-                    <label for="parcelNameInput">Rename parcel:</label>
-                    <input type="text" id="parcelNameInput" placeholder="New parcel name">
-                    <button id="renameParcelButton">Rename</button>
-                    <button id="closeRenameParcelOverlay">Cancel</button>
+                  <div id="pasteSummaryContent"></div>
+                  <button id="confirmPasteButton">Confirm</button>
+                  <button id="cancelPasteButton">Cancel</button>
                 </div>
-            </div>
-            <!-- Color Picker Popup -->
-            <div id="colorPickerOverlay" class="parcel-manipulation-overlay" style="display: none;">
-                <div class="parcel-manipulation-container">
-                    <label for="colorPickerInput">Change parcel color:</label>
-                    <input type="color" id="colorPickerInput">
-                    <button id="applyColorButton">Change</button>
-                    <button id="reset-color-btn">Reset Color</button>
-                    <button id="closeColorPickerOverlay">Cancel</button>
-                </div>
-            </div>
-            <!-- Move Popup -->
-            <div id="moveParcelOverlay" class="parcel-manipulation-overlay" style="display: none;">
-                <div class="parcel-manipulation-container">
-                    <label for="parcelMoveInput">Move parcel:</label>
-                    <div class="input-controller">
-                        <div class="input-btn" id="decreaseMoveAmount">-</div>
-                        <input type="number" id="parcelMoveInput" class="input-display" value="1" min="1" placeholder="Enter move amount">
-                        <div class="input-btn" id="increaseMoveAmount">+</div>
-                    </div>
-                    <button id="moveParcelButton">Move</button>
-                    <button id="closeMoveParcelOverlay">Cancel</button>
-                </div>
-            </div>
-            <!-- Paste Summary Popup -->
-            <div id="pasteSummaryOverlay" class="parcel-manipulation-overlay" style="display: none;">
-              <div class="parcel-manipulation-container">
-                <div id="pasteSummaryContent"></div>
-                <button id="confirmPasteButton">Confirm</button>
-                <button id="cancelPasteButton">Cancel</button>
               </div>
             </div>
-          </div>
-            <table class="table" id="resourceTable"></table>
-        </div>
-
-        <div class="game-section">
-          <h3 id="buildingHeader">Buildings</h3>
-          <div>
-            <input id="only-built" type="checkbox">
-            <label for="only-built">Show only built Buildings</label>
-          </div>
-          <div id="building-tabs">
-
+              <table class="table" id="resourceTable"></table>
           </div>
 
+          <div class="game-section">
+            <h3 id="buildingHeader">Buildings</h3>
+            <div>
+              <input id="only-built" type="checkbox">
+              <label for="only-built">Show only built Buildings</label>
+            </div>
+            <div id="building-tabs">
 
-          <table class="table" id="buildings">
-            <thead>
-              <tr>
-                <th>Building</th>
-                <th>Count</th>
-                <th>Action</th>
-              </tr>
-            </thead>
-            <tbody>
-              <!-- Buildings will be dynamically added here -->
-            </tbody>
-          </table>
+            </div>
 
+
+            <table class="table" id="buildings">
+              <thead>
+                <tr>
+                  <th>Building</th>
+                  <th>Count</th>
+                  <th>Action</th>
+                </tr>
+              </thead>
+              <tbody>
+                <!-- Buildings will be dynamically added here -->
+              </tbody>
+            </table>
+
+          </div>
         </div>
     </div>
 


### PR DESCRIPTION
The parcel and buildings buttons have been given a small gap, and the tables have been put in a flexbox with a gap which means they all appear on one screen. If you don't like the gaps you can easily adjust them, and also sorry if I should have put these in two separate pull requests.

I have read and agreed to the CLA